### PR TITLE
Update Homebrew instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ The same argument can also be passed via the `$IGREP_CUSTOM_EDITOR` environment 
 ### Prebuilt binaries
 `igrep` binaries can be downloaded from [GitHub](https://github.com/konradsz/igrep/releases).
 ### Homebrew
-```
-brew tap konradsz/igrep https://github.com/konradsz/igrep.git
+```zsh
 brew install igrep
 ```
 ### Scoop


### PR DESCRIPTION
`igrep` is in Homebrew proper now, so the `brew tap …` part isn’t needed anymore.