### PR TITLE
always switch to keymap input mode when it is open

### DIFF
--- a/src/ui/input_handler.rs
+++ b/src/ui/input_handler.rs
@@ -229,9 +229,10 @@ impl InputHandler {
             }),
             // misc
             "q" => consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_exit()),
-            "?" => {
-                consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_toggle_keymap())
-            }
+            "?" => consume_buffer_and_execute(&mut self.input_buffer, &mut || {
+                self.input_mode = InputMode::Keymap;
+                app.on_toggle_keymap();
+            }),
             "/" => {
                 self.input_mode = InputMode::TextInsertion;
                 consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_toggle_popup())


### PR DESCRIPTION
Fixes #86

Stumbled upon this today and then found the issue above. The correct behaviour is already implemented when opening the popup with <kbd>F1</kbd> but I forgot to trigger it on <kbd>?</kbd>.