### PR TITLE
Preserve ansi color sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "ansi-to-tui"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3bf628a79452df9614d933012dc500f8cb6ddad8c897ff8122ea1c0b187ff7"
+dependencies = [
+ "nom",
+ "ratatui",
+ "simdutf8",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,9 +132,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bstr"
@@ -142,9 +155,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
@@ -260,7 +273,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -499,6 +512,7 @@ dependencies = [
 name = "igrep"
 version = "1.3.0"
 dependencies = [
+ "ansi-to-tui",
  "anyhow",
  "clap",
  "crossterm",
@@ -632,6 +646,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +697,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -796,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
@@ -827,7 +857,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a564a852040e82671dc50a37d88f3aa83bbc690dfc6844cfe7a2591620206a80"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -847,7 +877,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -873,7 +903,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -969,6 +999,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.64"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ anyhow = "1.0.83"
 strum = { version = "0.26.2", features = ["derive"] }
 syntect = "5.2.0"
 which = "6.0.3"
+ansi-to-tui = "4"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,6 +36,7 @@ impl App {
         editor_command: EditorCommand,
         context_viewer: ContextViewer,
         theme: Box<dyn Theme>,
+        preserve_ansi: bool,
     ) -> Self {
         let theme = theme;
         Self {
@@ -43,7 +44,7 @@ impl App {
             ig: Ig::new(editor_command),
             theme,
             context_viewer,
-            result_list: ResultList::default(),
+            result_list: ResultList::new(preserve_ansi),
             search_popup: SearchPopup::default(),
             keymap_popup: KeymapPopup::default(),
         }

--- a/src/args.rs
+++ b/src/args.rs
@@ -78,6 +78,9 @@ pub struct Args {
     /// Sort results reverse, see ripgrep for details
     #[clap(long = "sortr")]
     pub sort_by_reverse: Option<SortKeyArg>,
+    /// Preserve ANSI escape codes.
+    #[clap(long)]
+    pub preserve_ansi: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/src/ig.rs
+++ b/src/ig.rs
@@ -80,7 +80,7 @@ impl Ig {
 
     pub fn search(&mut self, search_config: SearchConfig, result_list: &mut ResultList) {
         if self.state == State::Idle {
-            *result_list = ResultList::default();
+            result_list.reset();
             self.state = State::Searching;
             searcher::search(search_config, self.tx.clone());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ fn main() -> Result<()> {
         EditorCommand::new(args.editor.custom_command, args.editor.editor)?,
         ContextViewer::new(args.context_viewer),
         theme,
+        args.preserve_ansi,
     );
     app.run()?;
 


### PR DESCRIPTION
Implements #54 

Not ready for release yet:
- [ ] further manual testing
- [ ] automated testing
- [ ] better docs
- [ ] refactor of `ResultList::draw` for better readability
- [ ] dependency update (optional, but should be done soon; 4 major versions of [ansi-to-tui](https://crates.io/crates/ansi-to-tui/4.1.0) since its last version compatible with igreps version of ratatui; should be a separate PR, #85 is also out of date by now)